### PR TITLE
Fix - Look for .bat files since ruby 3 on mingw

### DIFF
--- a/src/Cake.Jekyll/JekyllTool.cs
+++ b/src/Cake.Jekyll/JekyllTool.cs
@@ -68,8 +68,8 @@ namespace Cake.Jekyll
         protected sealed override IEnumerable<string> GetToolExecutableNames()
         {
             return _useBundler
-                ? new[] { "bundle.cmd", "bundle.exe", "bundle" }
-                : new[] { "jekyll.cmd", "jekyll.exe", "jekyll" };
+                ? new[] { "bundle.bat", "bundle.cmd", "bundle.exe", "bundle" }
+                : new[] { "jekyll.bat", "jekyll.cmd", "jekyll.exe", "jekyll" };
         }
 
         /// <summary>


### PR DESCRIPTION
Propsed fix for [#31](https://github.com/cake-contrib/Cake.Jekyll/issues/31) on Ruby >= 3.0.0 where bundler is running in mingw.  New versions of ruby use ``.bat`` command launchers for the mingw subsystem.  This fix maintains compatibility for old/new.

Simple, check for ``.bat`` files additionally, as whether or not ruby involves ``.cmd`` or ``.bat`` versions of bundler mingw bootstrapper is based upon ruby version.