### PR TITLE
Update Cake.Jekyll build to use .NET SDK 7.0.101

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup net7.0
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: "7.0.100"
+          dotnet-version: "7.0.101"
       - name: Run dotnet --info
         run: dotnet --info
       - uses: actions/checkout@v3.2.0


### PR DESCRIPTION
Closes #49
